### PR TITLE
[FIX] signer.sign

### DIFF
--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -29,12 +29,21 @@ class Assinatura(object):
 
         ref_uri = ('#%s' % reference) if reference else None
 
-        signed_root = signer.sign(
-            xml_element,
-            key=self.certificado._chave,
-            cert=self.certificado._cert,
-            reference_uri=ref_uri
-        )
+        signed_root = False
+        try:
+            signed_root = signer.sign(
+                xml_element,
+                key=self.certificado.key,
+                cert=self.certificado.cert,
+                reference_uri=ref_uri
+            )
+        except TypeError:
+            signed_root = signer.sign(
+                xml_element,
+                key=self.certificado.key,
+                cert=self.certificado._cert,
+                reference_uri=ref_uri
+            )
 
         if reference:
             element_signed = signed_root.find(".//*[@Id='%s']" % reference)


### PR DESCRIPTION
`signer.sign( xml_element, key=self.certificado.key, cert=self.certificado.cert, reference_uri=ref_uri)`

A chamada acima causa o erro **TypeError: '_Certificate" object is not iterable**

No método **sign()** é encontrada a documentação:

> :param cert: X.509 certificate to use for signing. This should be a string containing a PEM-formatted certificate, or an array of strings or OpenSSL.crypto.X509 objects containing the certificate and a chain of intermediate certificates.`

Então o parâmetro cert=self.certificado.**cert** foi substituído por cert=self.certificado.**_cert**, que é um bytes[] contendo o certificado formatado.

Foi mantido a versão anterior do código para maior compatibilidade