### PR TITLE
requires Python 3.6+ for Endesive and install fix for recent pip versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,6 @@ from os.path import splitext
 from setuptools import find_packages
 from setuptools import setup
 
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
-install_reqs = parse_requirements('requirements.txt', session=False)
-
-reqs = [str(ir.req) for ir in install_reqs]
-
 
 def read(*names, **kwargs):
     with io.open(
@@ -84,7 +75,8 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=reqs,
+    install_requires=[r.strip() for r in
+                      open('requirements.txt').read().splitlines()],
     extras_require={
         # eg:
         #   'rst': ['docutils>=0.11'],

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -10,7 +10,7 @@ class Assinatura(object):
 
     def __init__(self, certificado):
         self.certificado = certificado
-    
+
     def assina_xml2(self, xml_element, reference):
         for element in xml_element.iter("*"):
             if element.text is not None and not element.text.strip():
@@ -48,7 +48,8 @@ class Assinatura(object):
         return etree.tostring(signed_root, encoding='utf8', method='xml')
 
 
-if sys.version_info > (3, 0):
+# endesive uses f-strings Syntax from Python 3.6+
+if sys.version_info > (3, 6):
     from endesive import pdf
     from endesive import signer
     from endesive import xades


### PR DESCRIPTION
endesive requires Python 3.6+ otherwise on Python 3.5.3 (Debian Strecth) you can have this error:
```
esse erro: alguem tem uma ideia? File "<frozen importlib._bootstrap>", line 969, in _find_and_load                   
 File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked       
 File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
 File "<frozen importlib._bootstrap_external>", line 673, in exec_module                        
 File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
 File "/usr/local/lib/python3.5/dist-packages/erpbrasil/assinatura/__init__.py", line 3, in <module>                                 
   from erpbrasil.assinatura.assinatura import Assinatura                                                          
 File "/usr/local/lib/python3.5/dist-packages/erpbrasil/assinatura/assinatura.py", line 52, in <module>
   from endesive import pdf                                                                 
 File "/usr/local/lib/python3.5/dist-packages/endesive/pdf/__init__.py", line 1, in <module>
   from . import cms                                                                        
 File "/usr/local/lib/python3.5/dist-packages/endesive/pdf/cms.py", line 13, in <module>    
   from endesive import signer                                                              
 File "/usr/local/lib/python3.5/dist-packages/endesive/signer.py", line 182
   tspheaders["Authorization"] = f"Basic {auth_header_value}"
```

On the contrary, using a recent pip version (pip 20.1.1) you get an installation error ```AttributeError: 'ParsedRequirement' object has no attribute 'req'``` very similar to https://github.com/erpbrasil/erpbrasil.transmissao/pull/4 so my second commit comes with a similar fix.