### PR TITLE
Correção dos requisitos mínimo para instalação

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ signxml==2.8.1
 cryptography==3.3.2
 endesive==2.0.1
 chardet==3.0.4
-xmlsec==1.3.8
+xmlsec==1.2.0


### PR DESCRIPTION
ao instalar o xmlsec 1.3.8 é encontrado o seguinte erro:

  Installing build dependencies ... done
    Complete output from command python setup.py egg_info:
    /tmp/pip-build-env-na9hgiik/lib/python3.7/site-packages/setuptools/dist.py:700: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
      % (opt, underscore_opt))
    /tmp/pip-build-env-na9hgiik/lib/python3.7/site-packages/setuptools/dist.py:700: UserWarning: Usage of dash-separated 'build-requires' will not be supported in future versions. Please use the underscore name 'build_requires' instead
      % (opt, underscore_opt))
    /tmp/pip-build-env-na9hgiik/lib/python3.7/site-packages/setuptools/dist.py:700: UserWarning: Usage of dash-separated 'upload-dir' will not be supported in future versions. Please use the underscore name 'upload_dir' instead
      % (opt, underscore_opt))
    Traceback (most recent call last):
      File "/tmp/pip-build-env-na9hgiik/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2739, in requires
        deps.extend(dm[safe_extra(ext)])
    KeyError: 'toml'
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-kc1s52_s/xmlsec/setup.py", line 466, in <module>
        package_data={'xmlsec': ['py.typed', '*.pyi']},
      File "/tmp/pip-build-env-na9hgiik/lib/python3.7/site-packages/setuptools/__init__.py", line 152, in setup
        _install_setup_requires(attrs)
      File "/tmp/pip-build-env-na9hgiik/lib/python3.7/site-packages/setuptools/__init__.py", line 147, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File "/tmp/pip-build-env-na9hgiik/lib/python3.7/site-packages/setuptools/dist.py", line 788, in fetch_build_eggs
        replace_conflicting=True,
      File "/tmp/pip-build-env-na9hgiik/lib/python3.7/site-packages/pkg_resources/__init__.py", line 780, in resolve
        new_requirements = dist.requires(req.extras)[::-1]
      File "/tmp/pip-build-env-na9hgiik/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2743, in requires
        ) from e
    pkg_resources.UnknownExtra: setuptools-scm 6.2.0 has no such extra feature 'toml'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-kc1s52_s/xmlsec/