### PR TITLE
Remove xmlsec

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.3.0
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,9 @@ Overview
     :alt: PyPI Package latest release
     :target: https://erpbrasilassinatura.readthedocs.io/en/latest/
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.assinatura/v1.2.0...svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.assinatura/v1.3.0...svg
     :alt: Commits since latest release
-    :target: https://github.com/erpbrasil/erpbrasil.assinatura/compare/v1.2.0...master
+    :target: https://github.com/erpbrasil/erpbrasil.assinatura/compare/v1.3.0...master
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/erpbrasil.assinatura.svg
     :alt: PyPI Wheel

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ project = 'erpbrasil.assinatura'
 year = '2019'
 author = 'Luis Felipe Mileo'
 copyright = '{0}, {1}'.format(year, author)
-version = release = '1.2.0'
+version = release = '1.3.0'
 
 pygments_style = 'trac'
 templates_path = ['.']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytz==2016.7
+cryptography==3.3.2
 signxml==2.8.2
 pycrypto==2.6.1
 endesive==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytz==2016.7
+pytz>=2016.7
 cryptography==3.3.2
 signxml==2.8.2
 pycrypto==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-pyopenssl==19.1.0
 pytz==2016.7
-signxml==2.8.1
-cryptography==3.3.2
+signxml==2.8.2
+pycrypto==2.6.1
 endesive==2.0.1
 chardet==3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ signxml==2.8.1
 cryptography==3.3.2
 endesive==2.0.1
 chardet==3.0.4
-xmlsec==1.3.8

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*names, **kwargs):
 
 setup(
     name='erpbrasil.assinatura',
-    version='1.2.0',
+    version='1.3.0',
     license='MIT license',
     description='Assinatura de documentos com certificados digitais A1 e A3',
     long_description='%s\n%s' % (

--- a/src/erpbrasil/assinatura/__init__.py
+++ b/src/erpbrasil/assinatura/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 from erpbrasil.assinatura.assinatura import Assinatura  # noqa: F401
 from erpbrasil.assinatura.certificado import Certificado  # noqa: F401

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -82,6 +82,18 @@ class Assinatura(object):
         if not self.chave_privada:
             raise Exception("Certificado não existe.")
 
+    def assina_string(self, message):
+        private_key = self.certificado.key
+        signature = private_key.sign(
+            message,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA1()),
+                salt_length=padding.PSS.MAX_LENGTH
+            ),
+            hashes.SHA1()
+        )
+        return signature
+
     def assina_pdf(self, arquivo, dados_assinatura, altoritimo='sha256'):
         return pdf.cms.sign(
             datau=arquivo,
@@ -98,18 +110,6 @@ class Assinatura(object):
             data=arquivo,
             trusted_cert_pems=certificados_de_confianca
         )
-
-    def assina_string(self, message):
-        private_key = self.certificado.key
-        signature = private_key.sign(
-            message,
-            padding.PSS(
-                mgf=padding.MGF1(hashes.SHA1()),
-                salt_length=padding.PSS.MAX_LENGTH
-            ),
-            hashes.SHA1()
-        )
-        return signature
 
     def assina_tag(self, message):
         message = b64encode(message).decode('utf-8')

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -74,39 +74,10 @@ class Assinatura(object):
         if not self.chave_privada:
             raise Exception("Certificado não existe.")
 
-    def assina_nfse(self, template):
-        self._checar_certificado()
 
-        key = xmlsec.Key.from_memory(
-            self.chave_privada,
-            format=xmlsec.constants.KeyDataFormatPem,
-            password=self.senha,
-        )
 
-        signature_node = xmlsec.template.create(
-            template,
-            c14n_method=consts.TransformInclC14N,
-            sign_method=consts.TransformRsaSha1,
-        )
-        template.append(signature_node)
-        ref = xmlsec.template.add_reference(
-            signature_node, consts.TransformSha1, uri=""
-        )
 
-        xmlsec.template.add_transform(ref, consts.TransformEnveloped)
-        xmlsec.template.add_transform(ref, consts.TransformInclC14N)
 
-        ki = xmlsec.template.ensure_key_info(signature_node)
-        xmlsec.template.add_x509_data(ki)
-
-        ctx = xmlsec.SignatureContext()
-        ctx.key = key
-
-        ctx.key.load_cert_from_memory(self.cert,
-                                      consts.KeyDataFormatPem)
-
-        ctx.sign(signature_node)
-        return etree.tostring(template, encoding=str)
 
     def assina_pdf(self, arquivo, dados_assinatura, altoritimo='sha256'):
         return pdf.cms.sign(

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -4,7 +4,6 @@ from base64 import b64encode
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from endesive import pdf
-from endesive import signer
 from lxml import etree
 from Crypto.PublicKey import RSA
 from Crypto.Hash import SHA

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -1,17 +1,13 @@
 # coding=utf-8
-
-from base64 import b64encode
-
 import signxml
-import xmlsec
+from OpenSSL import crypto
+from base64 import b64encode
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from endesive import pdf
 from endesive import signer
 from endesive import xades
 from lxml import etree
-from OpenSSL import crypto
-from xmlsec import constants as consts
 
 
 class Assinatura(object):
@@ -74,11 +70,6 @@ class Assinatura(object):
         if not self.chave_privada:
             raise Exception("Certificado não existe.")
 
-
-
-
-
-
     def assina_pdf(self, arquivo, dados_assinatura, altoritimo='sha256'):
         return pdf.cms.sign(
             datau=arquivo,
@@ -94,29 +85,6 @@ class Assinatura(object):
         return pdf.verify(
             data=arquivo,
             trusted_cert_pems=certificados_de_confianca
-        )
-
-    def assina_xml(self, arquivo):
-        def signproc(tosign, algosig):
-            key = self.certificado.key
-            signed_value_signature = key.sign(
-                tosign,
-                padding.PKCS1v15(),
-                getattr(hashes, algosig.upper())()
-            )
-            return signed_value_signature
-
-        cert = self.certificado.cert
-        certcontent = signer.cert2asn(cert).dump()
-
-        cls = xades.BES()
-        doc = cls.enveloping(
-            'documento.xml', arquivo, 'application/xml',
-            cert, certcontent, signproc, False, True
-        )
-
-        return etree.tostring(
-            doc, encoding='UTF-8', xml_declaration=True, standalone=False
         )
 
     def assina_string(self, message):

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -27,6 +27,24 @@ class Assinatura(object):
         digest = hasher.digest()
         return b64encode(digest).decode('utf-8')
 
+    def assina_xml(self, arquivo):
+        signer = signxml.XMLSigner(
+            method=signxml.methods.enveloped,
+            signature_algorithm="rsa-sha1",
+            digest_algorithm='sha1',
+            c14n_algorithm='http://www.w3.org/TR/2001/REC-xml-c14n-20010315'
+        )
+
+        root = etree.fromstring(arquivo)
+
+        signed_root = signer.sign(
+            root,
+            key=self.certificado.key,
+            cert=self.certificado._cert,
+        )
+
+        return etree.tostring(signed_root)
+
     def assina_xml2(self, xml_element, reference, getchildren=False):
         for element in xml_element.iter("*"):
             if element.text is not None and not element.text.strip():

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -103,7 +103,6 @@ class Assinatura(object):
 
         return signed_root
 
-    # USADA NAS FUNÇÕES DE TESTE
     def assina_string(self, message):
         private_key = self.certificado.key
         signature = private_key.sign(
@@ -116,7 +115,6 @@ class Assinatura(object):
         )
         return signature
 
-    # USADA NAS FUNÇÕES DE TESTE
     def assina_pdf(self, arquivo, dados_assinatura, altoritimo='sha256'):
         return pdf.cms.sign(
             datau=arquivo,
@@ -125,14 +123,6 @@ class Assinatura(object):
             cert=self.certificado.cert,
             othercerts=self.certificado.othercerts,
             algomd=altoritimo
-        )
-
-    # FUNÇÃO NÃO UTILIZADA
-    @staticmethod
-    def verifica_pdf(arquivo, certificados_de_confianca):
-        return pdf.verify(
-            data=arquivo,
-            trusted_cert_pems=certificados_de_confianca
         )
 
     def assina_tag(self, message):
@@ -144,7 +134,6 @@ class Assinatura(object):
         signature = signer.sign(message)
         return b64encode(signature).decode()
 
-    # USADA NAS FUNÇÕES DE TESTE
     def verificar_assinatura_string(self, message, signature):
         public_key = self.certificado.key.public_key()
         return public_key.verify(

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -108,14 +108,14 @@ class Assinatura(object):
         )
         return signature
 
-    def assina_pdf(self, arquivo, dados_assinatura, altoritimo='sha256'):
+    def assina_pdf(self, arquivo, dados_assinatura, algoritmo='sha256'):
         return pdf.cms.sign(
             datau=arquivo,
             udct=dados_assinatura,
             key=self.certificado.key,
             cert=self.certificado.cert,
             othercerts=self.certificado.othercerts,
-            algomd=altoritimo
+            algomd=algoritmo
         )
 
     def assina_tag(self, message):

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -1,17 +1,14 @@
 # coding=utf-8
 import signxml
-from OpenSSL import crypto
 from base64 import b64encode
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from endesive import pdf
 from endesive import signer
-from endesive import xades
 from lxml import etree
 from Crypto.PublicKey import RSA
 from Crypto.Hash import SHA
 from Crypto.Signature import PKCS1_v1_5
-from re import sub, search
 from hashlib import sha1
 
 
@@ -86,10 +83,6 @@ class Assinatura(object):
             digest_algorithm='sha1',
             c14n_algorithm='http://www.w3.org/TR/2001/REC-xml-c14n-20010315'
         )
-
-        ns = dict()
-        ns[None] = signer.namespaces['ds']
-        signer.namespaces = ns
 
         signed_root = signer.sign(
             xml_etree,


### PR DESCRIPTION
replaces  PR #21

Pessoal seria importante a gente testar esse PR, porque removendo essa dependência do xmlsec vai deixar a dependência essa lib muito mais simples. E não seria necessário integrar os PR #23

@marcelsavegnago,


Você conseguiria testar a emissão da NFS-e com esse PR?


cc @mileo @ygcarvalh @rvalyi