### PR TITLE
[FIX]  Passphrase Warning

### DIFF
--- a/src/erpbrasil/assinatura/certificado.py
+++ b/src/erpbrasil/assinatura/certificado.py
@@ -19,7 +19,7 @@ class Certificado(object):
     def __init__(self, arquivo, senha, raise_expirado=True):
         """Permite informar um arquivo PFX binario ou o path do arquivo"""
 
-        self._senha = senha
+        self._senha = senha.encode()
 
         try:
             try:
@@ -66,7 +66,7 @@ class Certificado(object):
         """
         return load_key_and_certificates(
             data=self._arquivo,
-            password=self._senha.encode(),
+            password=self._senha,
             backend=default_backend()
         )
 

--- a/src/erpbrasil/assinatura/certificado.py
+++ b/src/erpbrasil/assinatura/certificado.py
@@ -19,7 +19,7 @@ class Certificado(object):
     def __init__(self, arquivo, senha, raise_expirado=True):
         """Permite informar um arquivo PFX binario ou o path do arquivo"""
 
-        self._senha = senha.encode()
+        self._senha = self._encode_senha(senha)
 
         try:
             try:
@@ -113,6 +113,11 @@ class Certificado(object):
         """Retorna o arquivo pfx no formato binario pkc12"""
         return self._pkcs12
 
+    def _encode_senha(self, senha):
+        if type(senha) == str:
+            return senha.encode()
+        else:
+            return senha
 
 class ArquivoCertificado(object):
     """ Classe para ser utilizada quando for necessário salvar o arquivo

--- a/tests/test_erpbrasil_certificado.py
+++ b/tests/test_erpbrasil_certificado.py
@@ -43,3 +43,9 @@ class Tests(TestCase):
             self.assertTrue(os.path.exists(caminho_cert))
         self.assertFalse(os.path.exists(caminho_key))
         self.assertFalse(os.path.exists(caminho_cert))
+
+    def test_senha(self):
+        senha = self.certificado._encode_senha("123456")
+        self.assertTrue(type(senha) is bytes)
+        senha = self.certificado._encode_senha("123456".encode())
+        self.assertTrue(type(senha) is bytes)


### PR DESCRIPTION
Trivial FIX para corrigir o warning a baixo que está impedindo o trevis do odoo 14.0 ficar verdinho:

> 2022-01-16 14:42:17,463 166 WARNING openerp_test py.warnings: /.repo_requirements/virtualenv/python3.6/lib/python3.6/site-packages/erpbrasil/assinatura/certificado.py:30: DeprecationWarning: str for passphrase is no longer accepted, use bytes
> self._senha)