### PR TITLE
[CRITICAL] Remove pycrypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pytz>=2016.7
 cryptography==3.3.2
 signxml==2.8.2
-pycrypto==2.6.1
 endesive==2.0.1
 chardet==3.0.4


### PR DESCRIPTION
Pessoal,

A lib pycrypto não é mais mantida e tem problemas de vulnerabilidade https://github.com/erpbrasil/erpbrasil.assinatura/security/dependabot deve ser removida da dependência.