### PR TITLE
pyopenssl dependent endesive now optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pytz>=2016.7
 cryptography==3.3.2
 signxml==2.8.2
-endesive==2.0.1
 chardet==3.0.4

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -1,14 +1,16 @@
-# coding=utf-8
+import logging
 import signxml
 from base64 import b64encode
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
-from endesive import pdf
 from lxml import etree
 from Crypto.PublicKey import RSA
 from Crypto.Hash import SHA
 from Crypto.Signature import PKCS1_v1_5
 from hashlib import sha1
+
+
+_logger = logging.getLogger(__name__)
 
 
 class Assinatura(object):
@@ -126,6 +128,15 @@ class Assinatura(object):
         return signature
 
     def assina_pdf(self, arquivo, dados_assinatura, algoritmo='sha256'):
+        try:
+            from endesive import pdf
+        except ImportError:
+            _logger.info(
+                "assina_pdf requires the https://github.com/m32/endesive"
+                "package but it is not bundled by default"
+                "to avoid depending on pyopenssl which is deprecated"
+            )
+            return False
         return pdf.cms.sign(
             datau=arquivo,
             udct=dados_assinatura,

--- a/tests/test_erpbrasil_assinatura_pdf.py
+++ b/tests/test_erpbrasil_assinatura_pdf.py
@@ -1,5 +1,4 @@
-# coding=utf-8
-
+import logging
 import os
 import tempfile
 from datetime import datetime
@@ -18,6 +17,8 @@ certificado_ecpf_senha = os.environ.get('certificado_ecpf_senha', 'teste')
 
 test_path = os.environ.get('test_path', 'tests/')
 
+_logger = logging.getLogger(__name__)
+
 
 def test_assinatura_nfe_pdf():
     certificado = Certificado(certificado_nfe_caminho, certificado_nfe_senha, raise_expirado=False)
@@ -34,6 +35,16 @@ def test_assinatura_nfe_pdf():
             datetime.utcnow().strftime("%Y%M%d%H%M%S%Z")),
         'reason': 'Teste assinatura',
     }
+
+    try:
+        from endesive import pdf
+    except ImportError:
+        _logger.info(
+            "skipping test because https://github.com/m32/endesive"
+            "package but it is not installed. It is not bundled by default"
+            "to avoid depending on pyopenssl which is deprecated."
+        )
+    return False
 
     assinatura = assinador.assina_pdf(
         arquivo=arquivo,
@@ -60,6 +71,16 @@ def test_assinatura_multipla_pdf():
             datetime.utcnow().strftime("%Y%M%d%H%M%S%Z")),
         'reason': 'Teste Assinatura CPF',
     }
+
+    try:
+        from endesive import pdf
+    except ImportError:
+        _logger.info(
+            "skipping test because https://github.com/m32/endesive"
+            "package but it is not installed. It is not bundled by default"
+            "to avoid depending on pyopenssl which is deprecated."
+        )
+    return False
 
     assinatura1 = assinador_ecpf.assina_pdf(
         arquivo=arquivo,


### PR DESCRIPTION
o PR https://github.com/erpbrasil/erpbrasil.assinatura/pull/26 removeu o xmlsec mas não foi suficente para remover totalmente a dependencia ao pyopenssl que esta deprecaded ( https://github.com/erpbrasil/erpbrasil.assinatura/pull/26#issuecomment-1030113828 )

Porque o erpbrasil.assinatura ainda depende da lib endesive que por sua vez depende do pyopenssl sem pena:
https://github.com/m32/endesive/blob/master/requirements.txt

Como não usamos o endesive em nada do OCA/l10n-brazil, o que eu fiz foi de simplesmente deixar a dependencia ao endesive optional: a funçao de assinatura de pdf funciona apenas se vc tiver o endesive instalado e senão avisa num log. Talvez seria possivel fazer uma implementação alternativa, mas por hoje isso é a forma simpĺes que eu vi de remover a dependencia ao pyopenssl no uso comum que a gente faz do erpbrasil.assinatura.

cc @renatonlima @mbcosta @marcelsavegnago @netosjb @mileo 