### PR TITLE
[REF] Remover o método assina_tag

### DIFF
--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -4,9 +4,6 @@ from base64 import b64encode
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from lxml import etree
-from Crypto.PublicKey import RSA
-from Crypto.Hash import SHA
-from Crypto.Signature import PKCS1_v1_5
 from hashlib import sha1
 
 
@@ -145,15 +142,6 @@ class Assinatura(object):
             othercerts=self.certificado.othercerts,
             algomd=algoritmo
         )
-
-    def assina_tag(self, message):
-        privateKeyContent = (self.certificado._chave).decode('utf-8')
-        message = message.encode('utf-8')
-        message = SHA.new(message)
-        rsaKey = RSA.importKey(privateKeyContent)
-        signer = PKCS1_v1_5.new(rsaKey)
-        signature = signer.sign(message)
-        return b64encode(signature).decode()
 
     def verificar_assinatura_string(self, message, signature):
         public_key = self.certificado.key.public_key()


### PR DESCRIPTION
Após o merge da PR #26 foi adicionado a dependência a classe **[Crypto](https://github.com/Engenere/erpbrasil.assinatura/blob/e47223eb21c30b4b43f548fe2aaf18e8f7ff59b6/src/erpbrasil/assinatura/assinatura.py#L7-L9)**  que pelo que vi é da lib **pycrypto** porém a dependência desta lib não está declarada no arquivo [requirements.txt ](https://github.com/erpbrasil/erpbrasil.assinatura/blob/master/requirements.txt)

A minha duvida é: isso realmente é necessário ? pois já temos a lib cryptography para este fim.

Pelo que vi essa lib tá sendo usado somente no método  [assina_tag](https://github.com/erpbrasil/erpbrasil.assinatura/blob/e47223eb21c30b4b43f548fe2aaf18e8f7ff59b6/src/erpbrasil/assinatura/assinatura.py#L149) que é utilizado somente na nfs-e paulistana:

![image](https://user-images.githubusercontent.com/634278/159385398-2ccdd2a2-9539-4871-ba22-954f22e54814.png)

Mas também percebi que foi escrito um outro método chamado  [assina_string](https://github.com/erpbrasil/erpbrasil.assinatura/blob/e47223eb21c30b4b43f548fe2aaf18e8f7ff59b6/src/erpbrasil/assinatura/assinatura.py#L118) para o mesmo fim utilizando a lib cryptography, porém esse método não está sendo utilizado, será que esse método pode ser utilizado para substituir o assina_tag ? pois se sim podemos remover a dependência ao Crypto (pycrypto).

Caso contrário não é melhor adicionar o pycrypto no requeriments.txt ?

