### PR TITLE
[IMP] Criação do certificado falso

### DIFF
--- a/src/erpbrasil/assinatura/__init__.py
+++ b/src/erpbrasil/assinatura/__init__.py
@@ -2,3 +2,4 @@ __version__ = '1.3.0'
 
 from erpbrasil.assinatura.assinatura import Assinatura  # noqa: F401
 from erpbrasil.assinatura.certificado import Certificado  # noqa: F401
+from erpbrasil.assinatura.misc import *  # noqa: F401,F403

--- a/src/erpbrasil/assinatura/certificado.py
+++ b/src/erpbrasil/assinatura/certificado.py
@@ -119,6 +119,7 @@ class Certificado(object):
         else:
             return senha
 
+
 class ArquivoCertificado(object):
     """ Classe para ser utilizada quando for necessário salvar o arquivo
     temporariamente, garantindo a segurança que o mesmo sera salvo e apagado

--- a/src/erpbrasil/assinatura/misc.py
+++ b/src/erpbrasil/assinatura/misc.py
@@ -83,4 +83,3 @@ def create_fake_certificate_file(valid, passwd, issuer, country, subject):
     )
 
     return b64encode(p12)
-

--- a/src/erpbrasil/assinatura/misc.py
+++ b/src/erpbrasil/assinatura/misc.py
@@ -1,0 +1,86 @@
+"""
+Miscellaneous tools for Assinatura.
+"""
+import datetime
+from base64 import b64encode
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import BestAvailableEncryption
+from cryptography.hazmat.primitives.serialization.pkcs12 import (
+    serialize_key_and_certificates,
+)
+from cryptography.x509.oid import NameOID
+
+
+def create_fake_certificate_file(valid, passwd, issuer, country, subject):
+    """Creating a fake certificate
+
+    This certificate is useful to be used in test cases,
+    it is not valid to test the transmission of 'Notas Fiscais' in the homologation environment.
+
+    :param valid: True or False
+    :param passwd: Some password
+    :param issuer: Some string, like EMISSOR A TESTE
+    :param country: Some country: BR
+    :param subject: Some string: CERTIFICADO VALIDO TESTE
+    :return: base64 file
+    """
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+    public_key = private_key.public_key()
+    builder = x509.CertificateBuilder()
+
+    builder = builder.subject_name(
+        x509.Name(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, subject),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, country),
+            ]
+        )
+    )
+
+    builder = builder.issuer_name(
+        x509.Name(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, issuer),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, country),
+            ]
+        )
+    )
+
+    one_year = datetime.timedelta(365, 0, 0)
+    today = datetime.datetime.today()
+
+    if valid:
+        time_before = today
+        time_after = today + one_year
+    else:
+        time_before = today - one_year
+        time_after = today
+
+    builder = builder.not_valid_before(time_before)
+    builder = builder.not_valid_after(time_after)
+
+    builder = builder.serial_number(2009)
+
+    builder = builder.public_key(public_key)
+
+    certificate = builder.sign(
+        private_key=private_key,
+        algorithm=hashes.MD5(),
+    )
+
+    p12 = serialize_key_and_certificates(
+        name=subject.encode(),
+        key=private_key,
+        cert=certificate,
+        cas=None,
+        encryption_algorithm=BestAvailableEncryption(passwd.encode()),
+    )
+
+    return b64encode(p12)
+

--- a/tests/test_erpbrasil_assinatura_pdf.py
+++ b/tests/test_erpbrasil_assinatura_pdf.py
@@ -37,7 +37,7 @@ def test_assinatura_nfe_pdf():
     }
 
     try:
-        from endesive import pdf
+        from endesive import pdf  # noqa: F401
     except ImportError:
         _logger.info(
             "skipping test because https://github.com/m32/endesive"
@@ -73,7 +73,7 @@ def test_assinatura_multipla_pdf():
     }
 
     try:
-        from endesive import pdf
+        from endesive import pdf  # noqa: F401
     except ImportError:
         _logger.info(
             "skipping test because https://github.com/m32/endesive"

--- a/tests/test_erpbrasil_fake_certificate.py
+++ b/tests/test_erpbrasil_fake_certificate.py
@@ -1,0 +1,55 @@
+from unittest import TestCase
+import datetime
+from erpbrasil.assinatura.misc import create_fake_certificate_file
+from erpbrasil.assinatura import certificado
+from erpbrasil.assinatura.excecoes import CertificadoExpirado
+
+
+class Tests(TestCase):
+    """Simple test for fake certificate creation."""
+
+    def setUp(self):
+        self.cert_country = "BR"
+        self.cert_issuer_a = "EMISSOR A TESTE"
+        self.cert_issuer_b = "EMISSOR B TESTE"
+        self.cert_subject_valid = "CERTIFICADO VALIDO TESTE"
+        self.cert_date_exp = datetime.datetime.today() + datetime.timedelta(days=365)
+        self.cert_subject_invalid = "CERTIFICADO INVALIDO TESTE"
+        self.cert_passwd = "123456"
+        self.cert_name = "{} - {} - {} - Valid: {}".format(
+            "NF-E",
+            "A1",
+            self.cert_subject_valid,
+            self.cert_date_exp.strftime("%Y%M%d"),
+        )
+
+        self.certificate_valid = create_fake_certificate_file(
+            valid=True,
+            passwd=self.cert_passwd,
+            issuer=self.cert_issuer_a,
+            country=self.cert_country,
+            subject=self.cert_subject_valid,
+        )
+
+        self.certificate_invalid = create_fake_certificate_file(
+            valid=False,
+            passwd=self.cert_passwd,
+            issuer=self.cert_issuer_b,
+            country=self.cert_country,
+            subject=self.cert_subject_invalid,
+        )
+
+    def test_valid_certificate(self):
+        """Check a valid certificate"""
+        cert = certificado.Certificado(self.certificate_valid, self.cert_passwd)
+        self.assertEqual(cert.emissor, self.cert_issuer_a)
+        self.assertEqual(cert.proprietario, self.cert_subject_valid)
+        self.assertEqual(
+            cert.fim_validade.strftime("%Y%M%d"),
+            self.cert_date_exp.strftime("%Y%M%d")
+        )
+
+    def test_invalid_certificate(self):
+        """Check a invalid certificate"""
+        with self.assertRaises(CertificadoExpirado):
+            certificado.Certificado(self.certificate_invalid, self.cert_passwd)


### PR DESCRIPTION
Porte da funcionalidade da criação de certificado fake extraído da OCA https://github.com/OCA/l10n-brazil/pull/1778

Obs: esses certificados são úteis para testar as funcionalidades básicas internas, criação, exibição, validação, assinatura, etc.  Mas o seu uso é limitado a isso, ele não irá funcionar para testar um ambiente externo, por exemplo uma emissão de uma nota fiscal no ambiente de homologação, para isso a Sefaz ainda exige um certificado de verdade.