### PR TITLE
[REF] removido o uso do crypto do pyOpenSSL

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.4.0
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,9 @@ Overview
     :alt: PyPI Package latest release
     :target: https://erpbrasilassinatura.readthedocs.io/en/latest/
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.assinatura/v1.3.0...svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.assinatura/v1.4.0...svg
     :alt: Commits since latest release
-    :target: https://github.com/erpbrasil/erpbrasil.assinatura/compare/v1.3.0...master
+    :target: https://github.com/erpbrasil/erpbrasil.assinatura/compare/v1.4.0...master
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/erpbrasil.assinatura.svg
     :alt: PyPI Wheel

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ project = 'erpbrasil.assinatura'
 year = '2019'
 author = 'Luis Felipe Mileo'
 copyright = '{0}, {1}'.format(year, author)
-version = release = '1.3.0'
+version = release = '1.4.0'
 
 pygments_style = 'trac'
 templates_path = ['.']

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*names, **kwargs):
 
 setup(
     name='erpbrasil.assinatura',
-    version='1.3.0',
+    version='1.4.0',
     license='MIT license',
     description='Assinatura de documentos com certificados digitais A1 e A3',
     long_description='%s\n%s' % (

--- a/src/erpbrasil/assinatura/__init__.py
+++ b/src/erpbrasil/assinatura/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 
 from erpbrasil.assinatura.assinatura import Assinatura  # noqa: F401
 from erpbrasil.assinatura.certificado import Certificado  # noqa: F401

--- a/src/erpbrasil/assinatura/certificado.py
+++ b/src/erpbrasil/assinatura/certificado.py
@@ -14,7 +14,8 @@ from .excecoes import CertificadoSenhaInvalida
 from .excecoes import ErroDeLeituraDeArquivo
 
 
-class Certificado(object):
+class Certificado():
+    """Classe para representar o certificado digital"""
 
     def __init__(self, arquivo, senha, raise_expirado=True):
         """Permite informar um arquivo PFX binario ou o path do arquivo"""
@@ -65,9 +66,7 @@ class Certificado(object):
         :return:
         """
         return load_key_and_certificates(
-            data=self._arquivo,
-            password=self._senha,
-            backend=default_backend()
+            data=self._arquivo, password=self._senha, backend=default_backend()
         )
 
     @property
@@ -92,12 +91,13 @@ class Certificado(object):
 
     @property
     def cnpj_cpf(self):
+        """Pega o CNPJ ou CPF do proprietário do certificado"""
         # As vezes tem o nome e cnpj_cpf do proprietário
         proprietario = self.proprietario
-        if ':' in proprietario:
-            cnpj_cpf = proprietario.rsplit(':', 1)[1]
+        if ":" in proprietario:
+            cnpj_cpf = proprietario.rsplit(":", 1)[1]
             return cnpj_cpf
-        return ''
+        return ""
 
     @property
     def expirado(self):
@@ -120,8 +120,8 @@ class Certificado(object):
             return senha
 
 
-class ArquivoCertificado(object):
-    """ Classe para ser utilizada quando for necessário salvar o arquivo
+class ArquivoCertificado():
+    """Classe para ser utilizada quando for necessário salvar o arquivo
     temporariamente, garantindo a segurança que o mesmo sera salvo e apagado
     rapidamente
 
@@ -138,10 +138,10 @@ class ArquivoCertificado(object):
 
         cert, key = certificado.cert_chave()
 
-        tmp = os.fdopen(self.key_fd, 'w')
+        tmp = os.fdopen(self.key_fd, "w")
         tmp.write(cert)
 
-        tmp = os.fdopen(self.cert_fd, 'w')
+        tmp = os.fdopen(self.cert_fd, "w")
         tmp.write(key)
 
     def __enter__(self):
@@ -153,6 +153,7 @@ class ArquivoCertificado(object):
 
 
 def save_cert_key(cert, key):
+    """Salva o certificado e a chave em arquivos temporários"""
     cert_temp = tempfile.mkstemp()[1]
     key_temp = tempfile.mkstemp()[1]
 

--- a/src/erpbrasil/assinatura/excecoes.py
+++ b/src/erpbrasil/assinatura/excecoes.py
@@ -10,4 +10,4 @@ class ErroDeLeituraDeArquivo(Exception):
 
 
 class CertificadoSenhaInvalida(Exception):
-    """Lançado quando não é possível abrir um aquivo."""
+    """Lançado quando a senha informada é inválida"""


### PR DESCRIPTION
Conforme já foi discutido, o uso do módulo **crypto** do pyOpenSSL (OpenSSL.crypto) deve ser evitado.
Apesar das recentes alterações aqui na lib ainda tinha essa parte do código que fazia o seu uso.
Alterei o código para fazer o uso da lib cryptography. conforme é recomendado no site: https://www.pyopenssl.org/en/stable/api/crypto.html
![image](https://user-images.githubusercontent.com/634278/160949911-6223b90c-b54e-450c-91a3-3f6716f84660.png)
**Obs: não é necessário evitar totalmente o uso do PyOpenSSL, apenas o módulo * crypto * deve ser evitado!**
Mesmo agora, que todo o uso explicito da lib PyOpenSSL foi removido, ainda vamos ter dependência inderita, pois a lib **signxml** que é requerido aqui no erpbrasil.assinatura  tem dependência com o  PyOpenSSL, mas agora entendo que isso não é ruim.



