### PR TITLE
Relax dep versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz>=2016.7
-cryptography==3.3.2
-signxml==2.8.2
-chardet==3.0.4
+cryptography>=3.3.2
+signxml>=2.8.2
+chardet>=3.0.4

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -1,11 +1,11 @@
 import logging
-import signxml
 from base64 import b64encode
+from hashlib import sha1
+
+import signxml
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from lxml import etree
-from hashlib import sha1
-
 
 _logger = logging.getLogger(__name__)
 

--- a/src/erpbrasil/assinatura/certificado.py
+++ b/src/erpbrasil/assinatura/certificado.py
@@ -1,18 +1,13 @@
-# coding=utf-8
-
 import base64
+import datetime
 import os
 import tempfile
-import datetime
-
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.serialization.pkcs12 import (
-    load_key_and_certificates,
-)
-from cryptography.hazmat.primitives import serialization
-from cryptography.x509.oid import NameOID
 
 import pytz
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.serialization.pkcs12 import load_key_and_certificates
+from cryptography.x509.oid import NameOID
 
 from .excecoes import CertificadoExpirado
 from .excecoes import CertificadoSenhaInvalida
@@ -103,7 +98,6 @@ class Certificado():
     def cert_chave(self):
         """Retorna o certificado e a chave"""
         return self._cert.decode(), self._chave.decode()
-
 
     @staticmethod
     def _encode_senha(senha):

--- a/src/erpbrasil/assinatura/misc.py
+++ b/src/erpbrasil/assinatura/misc.py
@@ -3,13 +3,12 @@ Miscellaneous tools for Assinatura.
 """
 import datetime
 from base64 import b64encode
+
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import BestAvailableEncryption
-from cryptography.hazmat.primitives.serialization.pkcs12 import (
-    serialize_key_and_certificates,
-)
+from cryptography.hazmat.primitives.serialization.pkcs12 import serialize_key_and_certificates
 from cryptography.x509.oid import NameOID
 
 

--- a/tests/test_erpbrasil_fake_certificate.py
+++ b/tests/test_erpbrasil_fake_certificate.py
@@ -1,8 +1,9 @@
-from unittest import TestCase
 import datetime
-from erpbrasil.assinatura.misc import create_fake_certificate_file
+from unittest import TestCase
+
 from erpbrasil.assinatura import certificado
 from erpbrasil.assinatura.excecoes import CertificadoExpirado
+from erpbrasil.assinatura.misc import create_fake_certificate_file
 
 
 class Tests(TestCase):


### PR DESCRIPTION
foi colocado versões fixas nas dependencias sem que isso parece ser importante no projeto. Mais grave, hoje essas versões são bastante antigas o que facilmente cria conflito como acabou de acontecer na CI da localização Odoo da OCA:
https://github.com/OCA/l10n-brazil/pull/2113#issuecomment-1238394013

Aqui eu deixo essas versões mais livres para poder instalar versões mais recente (importante isso qdo se mexe com criptografia) e tb fiz um pouco de limpeza. De que adianta botar testes de isort para la e tox para ca se é para não respeitar?

de fato resolve o problema https://github.com/OCA/l10n-brazil/pull/2114

cc @renatonlima @marcelsavegnago @netosjb @mileo 