### PR TITLE
Fix namespaces

### DIFF
--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -55,9 +55,7 @@ class Assinatura(object):
             c14n_algorithm='http://www.w3.org/TR/2001/REC-xml-c14n-20010315'
         )
 
-        ns = dict()
-        ns[None] = signer.namespaces['ds']
-        signer.namespaces = ns
+        signer.namespaces = {"ds": "http://www.w3.org/2000/09/xmldsig#"}
 
         ref_uri = ('#%s' % reference) if reference else None
 

--- a/src/erpbrasil/assinatura/misc.py
+++ b/src/erpbrasil/assinatura/misc.py
@@ -70,7 +70,7 @@ def create_fake_certificate_file(valid, passwd, issuer, country, subject):
 
     certificate = builder.sign(
         private_key=private_key,
-        algorithm=hashes.MD5(),
+        algorithm=hashes.SHA3_512(),
     )
 
     p12 = serialize_key_and_certificates(


### PR DESCRIPTION
Após a atualização da lib signxml (>2.9.0) a emissão da nota fiscal passou a ser rejeitada pelo seguinte motivo:

**Rejeitada: 297 - Rejeicao: Assinatura difere do calculado**

O motivo é que a lib singxml a partir da versão 2.10.0 não aceita mais as tags com o namespace vazios (empty xmlns), ver: https://github.com/XML-Security/signxml/issues/197#issuecomment-1312609706

Por esse motivo fiz uma correção no método de assinatura para o namespace seja colocado corretamente.

### Sem a correção:

```
<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
            <SignedInfo>
                <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
                <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
                <Reference URI="#NFe42221204319621000193550010000000061994688405">
                    <Transforms>
                        <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
                        <Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
                    </Transforms>
                    <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
                    <DigestValue>cqLWGFk0QtiQ1m9OP9qWzeww7Uo=</DigestValue>
                </Reference>
            </SignedInfo>
            <SignatureValue>
eVY0GA2ZqS7t7ZC0YdpGNdMvGY7gNx3+zoq3Q77YKn48Q4cO3qRmjD2F3gbFRiHoURvCpnIv+SfeS/h7slz71+0e2/cxifBLkB1kBSdWv9qermVD3w9nxnVh2cfrClbGDTZJaW95PnKkaIN8PN9k8vVl2GFKJWYGllNJYCM1G6fgOU/2cZVAuz7pHqMG2FCWfMbx0ruNkfT2+uYZz0pLm9QfMylZWN+0W1ZiKzH9jhWrbtnAFrpmPHmsrFG05qNQFq9flSU3Ob+Vc4aKAbgy3SOiBdIJ0OL3aCK2O0Sr8GJeRo7mC8+tO1iMU51+Dzptpn+N4AjFub6xAjbsbvyWrg==</SignatureValue>
            <KeyInfo>
                <X509Data>
                    <X509Certificate>MIIHdjCCBV6gAwIBAgINANApyJ+54Yypp3rMGzANBgkqhkiG9w0BAQsFADCBiTEL
                        MAkGA1UEBhMCQlIxEzARBgNVBAoMCklDUC1CcmFzaWwxNjA0BgNVBAsMLVNlY3Jl
                        dGFyaWEgZGEgUmVjZWl0YSBGZWRlcmFsIGRvIEJyYXNpbCAtIFJGQjEtMCsGA1UE
                        AwwkQXV0b3JpZGFkZSBDZXJ0aWZpY2Fkb3JhIFNFUlBST1JGQnY1MB4XDTIyMDky
                        MjEyNDAxMFoXDTIzMDkyMjEyNDAxMFowggEQMQswCQYDVQQGEwJCUjELMAkGA1UE
                        CAwCU0MxGTAXBgNVBAcMEFNBTyBKT0FPIEJBVElTVEExEzARBgNVBAoMCklDUC1C
                        cmFzaWwxGTAXBgNVBAsMEHZpZGVvY29uZmVyZW5jaWExFzAVBgNVBAsMDjAzNDAy
                        ODE5MDAwMTczMTYwNAYDVQQLDC1TZWNyZXRhcmlhIGRhIFJlY2VpdGEgRmVkZXJh
                        bCBkbyBCcmFzaWwgLSBSRkIxFDASBgNVBAsMC0FSSU5GT0NPTUVYMRYwFAYDVQQL
                        DA1SRkIgZS1DTlBKIEExMSowKAYDVQQDDCFLTCBFTUJBTEFHRU5TIExUREE6MDQz
                        MTk2MjEwMDAxOTMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDDgaFO
                        l0G5ifwnprkiwJcDmvBHW6+ySu8boIYLhBEyy0LBEkzldkRUqngs3jKLU5e385S6
                        B2tEgrA5+npZVOYp1mWgEmoRxc+Ku8vTQ6cyB2dh2x0CgX7LgxncNRgGntMWbRr1
                        hbsva9pOtcD73aUOsh8kxvu0TTg1ca4x213FHbxscz3mAbv3sd830MA75hQ2qD7J
                        kx1t1vDp4SW+YTppRWp9Ubiz/ujl9NaoS3FvoHQrrKodD++WIpo55Mi1IbR5Ow0i
                        /tr5uXcSTHRFdcKm0ngET1oUCzzl/SnqbQnk8wOqjoID2ugB8ew2znPXLi+5xLps
                        KIGADobTzyfenGipAgMBAAGjggJRMIICTTAfBgNVHSMEGDAWgBQUgC2dfppFwPFb
                        PxnVQLBvL2Xg6TCBiAYDVR0fBIGAMH4wPKA6oDiGNmh0dHA6Ly9yZXBvc2l0b3Jp
                        by5zZXJwcm8uZ292LmJyL2xjci9hY3NlcnByb3JmYnY1LmNybDA+oDygOoY4aHR0
                        cDovL2NlcnRpZmljYWRvczIuc2VycHJvLmdvdi5ici9sY3IvYWNzZXJwcm9yZmJ2
                        NS5jcmwwVgYIKwYBBQUHAQEESjBIMEYGCCsGAQUFBzAChjpodHRwOi8vcmVwb3Np
                        dG9yaW8uc2VycHJvLmdvdi5ici9jYWRlaWFzL2Fjc2VycHJvcmZidjUucDdiMIG6
                        BgNVHREEgbIwga+gOAYFYEwBAwSgLwQtMjUwOTE5NTQzMTM2NTc5NTkzNDAwMDAw
                        MDAwMDAwMDAwMDAwMDAwMDAwMDAwoB8GBWBMAQMCoBYEFExVSVogQU5UT05JTyBQ
                        RVJFSVJBoBkGBWBMAQMDoBAEDjA0MzE5NjIxMDAwMTkzoBcGBWBMAQMHoA4EDDAw
                        MDAwMDAwMDAwMIEeZmluYW5jZWlyb0BrbGVtYmFsYWdlbnMuY29tLmJyMA4GA1Ud
                        DwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwIwWwYDVR0g
                        BFQwUjBQBgZgTAECAQowRjBEBggrBgEFBQcCARY4aHR0cDovL3JlcG9zaXRvcmlv
                        LnNlcnByby5nb3YuYnIvZG9jcy9kcGNhY3NlcnByb3JmYi5wZGYwDQYJKoZIhvcN
                        AQELBQADggIBAKFEIZhoI2BpYNPu/kPpdFXaXwlysDIT8JwacbcqDO0CY221AYU/
                        7zYdYsG7nMbVbVy7jcGt2mDczABtvBK3Hcjc0vH6wSl++OnsgmC3mMKkXreUeNPZ
                        djT+h+BKM2ZYIi18vGvodT1cB88DjwBmYmAiJmwIhFeAjWq/I1QwyECPhfYA9jfr
                        sS19WnLtLecHqGlt0+WNBnG4BTVX/9sL3VWv72HCzOzPrCryGEDU36wL+3CDfZNF
                        egLaJVllFpcDN6g1BnzutE3nZicf7kymXowcvyAFVsG3yA13+a7abne5W/bA/O6X
                        jjrwQDl0/irXbef6MNwcIQ/2Xux051ctOd1Z1C1gyMhldonumFhtnUWTmNKyI1oC
                        DzfeJaZCJliaEyP6Y1UyUHtNzooVqvueJei5VJTd6fUjmpLJ/4GWVWGfYpk/iF+v
                        F6vJbBwwPbAE/TDAE4XpMXdFRqTap4bpSKfGFjmzfRq8+OpsDlro8RWkxPoRpxCT
                        CnvQ9p0ugy3V9o3E2fae2qCvNvUW463jPNiqjYTyWMhL3b2v2UzEE5+bLHxp4j6z
                        GDwqR1M9x5Wwaw30N8NP1v0VfmralQxzUYNylaPpd62CpsqXSqu5NA53pnctYd9K
                        igTVTxeLSWRgt2eHhoId7k9Jg+eLNYT/wkHsi4LQusGLPdtVXPyy0o1R
                    </X509Certificate>
                </X509Data>
            </KeyInfo>
        </Signature>
```

### Com a correção:

```
<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
    <ds:SignedInfo>
        <ds:CanonicalizationMethod
            Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
        <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
        <ds:Reference URI="#NFe42221204319621000193550010000000061994688405">
            <ds:Transforms>
                <ds:Transform
                    Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
                <ds:Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
            </ds:Transforms>
            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
            <ds:DigestValue>cqLWGFk0QtiQ1m9OP9qWzeww7Uo=</ds:DigestValue>
        </ds:Reference>
    </ds:SignedInfo>
    <ds:SignatureValue>
        kG/KrB1qaJXtJWfwGSvu/84tIB/i5xBqfD/KGGTRY3dssmUoesWpQkEzLc9ClMIeA6SZgNIzcZlY7A2ReW/9Zwe0VCpQpABzzYBrEIIEzSXCi/+ErR77PfdyNnGOZPOiYRpcZZywccOOhJLF8jeqjD8VpKPz5QMHZPDVBmXGZ+bKnefYWkxAAeooITYRuU1pBYzrSE2hNJQcUTmFbwPbUA1cHIhHLLMeJ7YyGfrSzRV7jArm0bUncEPc6yA/+Pb+D5UzrMnRUJTyx2Aavcz8vVqBVH1k5q5rEXNASblFN//6CIXxcoIg0OCejB75TMaKf+37mYGC8rOwHLXWw7UX7A==</ds:SignatureValue>
    <ds:KeyInfo>
        <ds:X509Data>
            <ds:X509Certificate>MIIHdjCCBV6gAwIBAgINANApyJ+54Yypp3rMGzANBgkqhkiG9w0BAQsFADCBiTEL
                MAkGA1UEBhMCQlIxEzARBgNVBAoMCklDUC1CcmFzaWwxNjA0BgNVBAsMLVNlY3Jl
                dGFyaWEgZGEgUmVjZWl0YSBGZWRlcmFsIGRvIEJyYXNpbCAtIFJGQjEtMCsGA1UE
                AwwkQXV0b3JpZGFkZSBDZXJ0aWZpY2Fkb3JhIFNFUlBST1JGQnY1MB4XDTIyMDky
                MjEyNDAxMFoXDTIzMDkyMjEyNDAxMFowggEQMQswCQYDVQQGEwJCUjELMAkGA1UE
                CAwCU0MxGTAXBgNVBAcMEFNBTyBKT0FPIEJBVElTVEExEzARBgNVBAoMCklDUC1C
                cmFzaWwxGTAXBgNVBAsMEHZpZGVvY29uZmVyZW5jaWExFzAVBgNVBAsMDjAzNDAy
                ODE5MDAwMTczMTYwNAYDVQQLDC1TZWNyZXRhcmlhIGRhIFJlY2VpdGEgRmVkZXJh
                bCBkbyBCcmFzaWwgLSBSRkIxFDASBgNVBAsMC0FSSU5GT0NPTUVYMRYwFAYDVQQL
                DA1SRkIgZS1DTlBKIEExMSowKAYDVQQDDCFLTCBFTUJBTEFHRU5TIExUREE6MDQz
                MTk2MjEwMDAxOTMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDDgaFO
                l0G5ifwnprkiwJcDmvBHW6+ySu8boIYLhBEyy0LBEkzldkRUqngs3jKLU5e385S6
                B2tEgrA5+npZVOYp1mWgEmoRxc+Ku8vTQ6cyB2dh2x0CgX7LgxncNRgGntMWbRr1
                hbsva9pOtcD73aUOsh8kxvu0TTg1ca4x213FHbxscz3mAbv3sd830MA75hQ2qD7J
                kx1t1vDp4SW+YTppRWp9Ubiz/ujl9NaoS3FvoHQrrKodD++WIpo55Mi1IbR5Ow0i
                /tr5uXcSTHRFdcKm0ngET1oUCzzl/SnqbQnk8wOqjoID2ugB8ew2znPXLi+5xLps
                KIGADobTzyfenGipAgMBAAGjggJRMIICTTAfBgNVHSMEGDAWgBQUgC2dfppFwPFb
                PxnVQLBvL2Xg6TCBiAYDVR0fBIGAMH4wPKA6oDiGNmh0dHA6Ly9yZXBvc2l0b3Jp
                by5zZXJwcm8uZ292LmJyL2xjci9hY3NlcnByb3JmYnY1LmNybDA+oDygOoY4aHR0
                cDovL2NlcnRpZmljYWRvczIuc2VycHJvLmdvdi5ici9sY3IvYWNzZXJwcm9yZmJ2
                NS5jcmwwVgYIKwYBBQUHAQEESjBIMEYGCCsGAQUFBzAChjpodHRwOi8vcmVwb3Np
                dG9yaW8uc2VycHJvLmdvdi5ici9jYWRlaWFzL2Fjc2VycHJvcmZidjUucDdiMIG6
                BgNVHREEgbIwga+gOAYFYEwBAwSgLwQtMjUwOTE5NTQzMTM2NTc5NTkzNDAwMDAw
                MDAwMDAwMDAwMDAwMDAwMDAwMDAwoB8GBWBMAQMCoBYEFExVSVogQU5UT05JTyBQ
                RVJFSVJBoBkGBWBMAQMDoBAEDjA0MzE5NjIxMDAwMTkzoBcGBWBMAQMHoA4EDDAw
                MDAwMDAwMDAwMIEeZmluYW5jZWlyb0BrbGVtYmFsYWdlbnMuY29tLmJyMA4GA1Ud
                DwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwIwWwYDVR0g
                BFQwUjBQBgZgTAECAQowRjBEBggrBgEFBQcCARY4aHR0cDovL3JlcG9zaXRvcmlv
                LnNlcnByby5nb3YuYnIvZG9jcy9kcGNhY3NlcnByb3JmYi5wZGYwDQYJKoZIhvcN
                AQELBQADggIBAKFEIZhoI2BpYNPu/kPpdFXaXwlysDIT8JwacbcqDO0CY221AYU/
                7zYdYsG7nMbVbVy7jcGt2mDczABtvBK3Hcjc0vH6wSl++OnsgmC3mMKkXreUeNPZ
                djT+h+BKM2ZYIi18vGvodT1cB88DjwBmYmAiJmwIhFeAjWq/I1QwyECPhfYA9jfr
                sS19WnLtLecHqGlt0+WNBnG4BTVX/9sL3VWv72HCzOzPrCryGEDU36wL+3CDfZNF
                egLaJVllFpcDN6g1BnzutE3nZicf7kymXowcvyAFVsG3yA13+a7abne5W/bA/O6X
                jjrwQDl0/irXbef6MNwcIQ/2Xux051ctOd1Z1C1gyMhldonumFhtnUWTmNKyI1oC
                DzfeJaZCJliaEyP6Y1UyUHtNzooVqvueJei5VJTd6fUjmpLJ/4GWVWGfYpk/iF+v
                F6vJbBwwPbAE/TDAE4XpMXdFRqTap4bpSKfGFjmzfRq8+OpsDlro8RWkxPoRpxCT
                CnvQ9p0ugy3V9o3E2fae2qCvNvUW463jPNiqjYTyWMhL3b2v2UzEE5+bLHxp4j6z
                GDwqR1M9x5Wwaw30N8NP1v0VfmralQxzUYNylaPpd62CpsqXSqu5NA53pnctYd9K
                igTVTxeLSWRgt2eHhoId7k9Jg+eLNYT/wkHsi4LQusGLPdtVXPyy0o1R
            </ds:X509Certificate>
        </ds:X509Data>
    </ds:KeyInfo>
</ds:Signature>
```

Obs: Aproveitei e já alterei o método de criação do certificado fake para um algorítimo de criptografia mais forte, para ficar mais semelhante a um certificado de verdade.