### PR TITLE
[FIX] cryptography version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz>=2016.7
-cryptography>=3.3.2
+cryptography>=3.3.2,<39
 signxml>=2.8.2
 chardet>=3.0.4


### PR DESCRIPTION
Dia 02/01/2023 houve uma atualização da lib cryptography pra versão 39.0.0 e acabou descontinuando o suporte para o algoritmo md5. Ao tentar submeter os testes do PR na localização (l10n-brazil), isso acabou gerando o seguinte erro:

![image](https://user-images.githubusercontent.com/50669363/210374079-0fa0a92b-1ae6-4130-8221-580033ab1601.png)

Eu investiguei e a única explicação seria realmente essa, já que na própria versão 38.0.4 existe um warning avisando de que esse algoritmo seria descontinuado.

Com isso, essa correção faz com que ainda seja mantido o primeiro critério que o Raphael adicionou, mas impede que seja instalado a versão mais recente. Dessa forma, ele vai se manter na versão 38.0.4 e isso já impede que o erro aconteça.

Sugestões são sempre bem-vindas.

@mileo @rvalyi @renatonlima