### PR TITLE
avoids recent SHA1-based algorithms deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz>=2016.7
 cryptography>=3.3.2
-signxml>=2.8.2
+signxml>=2.8.2,<3.1.0
 chardet>=3.0.4


### PR DESCRIPTION
mesmo workaround do que na localização brasileira do Odoo https://github.com/OCA/l10n-brazil/pull/2289 até que seja refatorado o código para evitar esses erros como ```signxml.exceptions.InvalidInput: SHA1-based algorithms are not supported in the default configuration because they are not secure```.

Nota: essa versão 3.1.0 do signxml que a gente esta proibindo aqui é recente, é do 13 Nov 2022. A ultima versão que funciona com erpbrasil.assinatura, é a 2.10.1 que tb é recente, do 9 de Setembro 2022.