### PR TITLE
Suporte ao SHA1 nas versões mais recentes do signxml.

### DIFF
--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -10,6 +10,19 @@ from lxml import etree
 _logger = logging.getLogger(__name__)
 
 
+class XMLSignerWithSHA1(signxml.XMLSigner):
+    """
+    Extension of the `XMLSigner` class that adds support for the SHA1 hash algorithm
+    to the XML signature process.
+    Note:
+        SHA1-based algorithms are not supported in the default configuration because
+        they are not secure, but in the NF-e project, other more modern algorithms
+        are still not accepted.
+    """
+    def check_deprecated_methods(self):
+        "Override to disable deprecated Check"
+
+
 class Assinatura(object):
 
     def __init__(self, certificado):
@@ -48,7 +61,7 @@ class Assinatura(object):
             if element.text is not None and not element.text.strip():
                 element.text = None
 
-        signer = signxml.XMLSigner(
+        signer = XMLSignerWithSHA1(
             method=signxml.methods.enveloped,
             signature_algorithm="rsa-sha1",
             digest_algorithm='sha1',
@@ -91,7 +104,7 @@ class Assinatura(object):
 
     def assina_nfse(self, xml_etree):
 
-        signer = signxml.XMLSigner(
+        signer = XMLSignerWithSHA1(
             method=signxml.methods.enveloped,
             signature_algorithm="rsa-sha1",
             digest_algorithm='sha1',

--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -68,7 +68,8 @@ class Assinatura(object):
             c14n_algorithm='http://www.w3.org/TR/2001/REC-xml-c14n-20010315'
         )
 
-        signer.namespaces = {"ds": "http://www.w3.org/2000/09/xmldsig#"}
+        signer.excise_empty_xmlns_declarations = True
+        signer.namespaces = {None: signxml.namespaces.ds}
 
         ref_uri = ('#%s' % reference) if reference else None
 


### PR DESCRIPTION
A partir da [versão 3.1.0 do signxml](https://github.com/XML-Security/signxml/releases/tag/v3.1.0) o SHA1 é obsoleto por padrão.

O SHA1 é  o padrão para a maioria dos projetos de documentos fiscais brasileiros, como por o exemplo a NF-e, que não aceita outros algoritmos mais modernos como o SHA-256 ou SHA-512.

Para contornar isso e permitir a utilização das versões mais recentes, foi feito uma extensão na configuração padrão para permitir a utilização do SHA1.

Outro problema que aproveitei para resolver é que em alguns casos, dependendo o certificado digital utilizado, a emissão de uma nota fiscal era rejeitada pelo motivo **290 - Certificado Assinatura Inválido.**
![certificado assinatura invalido](https://user-images.githubusercontent.com/634278/235517115-238e81bf-7bd9-451f-a64a-2aeb17f68298.png)
Esse erro só acontecia quando era definido os prefixos/namespace nas tags da assinatura.
Por isso removi o prefixo e namespace padrão, a lib signxml por padrão também não está mais aceitando essas declarações vazias, por isso é preciso ativar  a flag **excise_empty_xmlns_declarations** 

