### PR TITLE
[IMP] add sign method for RPS additional sign for NFS-e Paulistana

### DIFF
--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -103,10 +103,7 @@ class Assinatura(object):
             key=self.chave_privada,
             cert=self.cert,
         )
-
         signed_root = etree.tostring(signed_root, encoding=str)
-
-        signed_root = signed_root.replace('\r', '').replace('\n', '')
 
         return signed_root
 
@@ -118,6 +115,26 @@ class Assinatura(object):
                 mgf=padding.MGF1(hashes.SHA1()),
                 salt_length=padding.PSS.MAX_LENGTH
             ),
+            hashes.SHA1()
+        )
+        return signature
+
+    def sign_pkcs1v15_sha1(self, data):
+        """
+        Sign data using PKCS1v15 padding and SHA1 hash algorithm.
+
+        This method is specifically tailored for the NFSe Paulistana RPS signing process.
+
+        Args:
+            data (bytes): Data to be signed.
+
+        Returns:
+            bytes: Generated signature.
+        """
+        private_key = self.certificado.key
+        signature = private_key.sign(
+            data,
+            padding.PKCS1v15(),
             hashes.SHA1()
         )
         return signature


### PR DESCRIPTION
Adiciona um método específico para gerar assinatura adicional que é inclusa nos RPC da NFS-e Paulistana.

Antigamente era utilizado o método assina_tag que foi removido aqui: https://github.com/erpbrasil/erpbrasil.assinatura/pull/31
Na época pensei que poderia ser utilizado o método `assina_string` mas o mesmo utiliza uma configuração que não é compatível com a NFS-e Paulistana, por esse motivo criei um método exclusivo para este fim.




