### PR TITLE
[UPD] Atualizando o Warning 'naive datetime obj deprecated', apenas para casos onde o PyOpenSSL está atualizado

### DIFF
--- a/src/erpbrasil/assinatura/certificado.py
+++ b/src/erpbrasil/assinatura/certificado.py
@@ -1,9 +1,9 @@
 import base64
-import datetime
 import os
 import tempfile
 
 import pytz
+from datetime import datetime, timezone
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.serialization.pkcs12 import load_key_and_certificates
@@ -60,12 +60,12 @@ class Certificado():
     @property
     def inicio_validade(self):
         """Pega a data inicial de validade do certificado"""
-        return self.cert.not_valid_before.replace(tzinfo=pytz.UTC)
+        return self.cert.not_valid_before_utc
 
     @property
     def fim_validade(self):
         """Pega a data final de validade do certificado"""
-        return self.cert.not_valid_after.replace(tzinfo=pytz.UTC)
+        return self.cert.not_valid_after_utc
 
     @property
     def emissor(self):
@@ -90,8 +90,7 @@ class Certificado():
     @property
     def expirado(self):
         """Verifica se o certificado está expirado"""
-        today = datetime.datetime.today()
-        if today > self.cert.not_valid_after:
+        if datetime.now(timezone.utc) > self.cert.not_valid_after_utc:
             return True
         return False
 


### PR DESCRIPTION
O **Cryptography** em versões mais recentes está retornando a mensagem de deprecated: 

py.warnings: /usr/local/lib/python3.10/site-packages/erpbrasil/assinatura/certificado.py:94: CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_after_utc.

Isso pode acabar aparecendo no LOGs de programas que estão usando a LIB, por exemplo:

```bash
2025-02-02 20:30:17,868 97 WARNING odoo py.warnings: /usr/local/lib/python3.10/site-packages/erpbrasil/assinatura/certificado.py:94: CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_after_utc.
  File "/usr/local/bin/odoo", line 8, in <module>
    odoo.cli.main()
  File "/usr/local/lib/python3.10/site-packages/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/usr/local/lib/python3.10/site-packages/odoo/cli/server.py", line 185, in run
    main(args)
  File "/usr/local/lib/python3.10/site-packages/odoo/cli/server.py", line 178, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/usr/local/lib/python3.10/site-packages/odoo/service/server.py", line 1410, in start
    rc = server.run(preload, stop)
  File "/usr/local/lib/python3.10/site-packages/odoo/service/server.py", line 590, in run
    rc = preload_registries(preload)
  File "/usr/local/lib/python3.10/site-packages/odoo/service/server.py", line 1310, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/usr/local/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/usr/local/lib/python3.10/site-packages/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/odoo/modules/registry.py", line 91, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/usr/local/lib/python3.10/site-packages/odoo/modules/loading.py", line 488, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/usr/local/lib/python3.10/site-packages/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/usr/local/lib/python3.10/site-packages/odoo/modules/loading.py", line 249, in load_module_graph
    getattr(py_module, post_init)(cr, registry)
  File "/home/odoo/app/external-src/l10n-brazil-MIG-l10n_br_delivery-29_01_2025/l10n_br_fiscal_certificate/hooks.py", line 47, in post_init_hook
    company.certificate_nfe_id = l10n_br_fiscal_certificate_id.create(
  File "<decorator-gen-428>", line 2, in create
  File "/usr/local/lib/python3.10/site-packages/odoo/api.py", line 414, in _model_create_multi
    return create(self, [arg])
  File "/home/odoo/app/external-src/l10n-brazil-MIG-l10n_br_delivery-29_01_2025/l10n_br_fiscal_certificate/models/certificate.py", line 132, in create
    self.update_certificate_data(vals)
  File "/home/odoo/app/external-src/l10n-brazil-MIG-l10n_br_delivery-29_01_2025/l10n_br_fiscal_certificate/models/certificate.py", line 119, in update_certificate_data
    values.update(self._certificate_data(cert_file, values.get("password")))
  File "/home/odoo/app/external-src/l10n-brazil-MIG-l10n_br_delivery-29_01_2025/l10n_br_fiscal_certificate/models/certificate.py", line 67, in _certificate_data
    cert = certificado.Certificado(cert_file, cert_password)
  File "/usr/local/lib/python3.10/site-packages/erpbrasil/assinatura/certificado.py", line 42, in __init__
    if raise_expirado and self.expirado:
  File "/usr/local/lib/python3.10/site-packages/erpbrasil/assinatura/certificado.py", line 94, in expirado
    if today > self.cert.not_valid_after:
```  

Esse PR está antecipando a mudança, porque no caso do Odoo na v16 acabei vendo que devido o **PyOpenSSL** a versão do **Cryptography** usada ainda é a  **<39**

https://github.com/OCA/l10n-brazil/actions/runs/13143724673/job/36676790284?pr=3611#step:5:190

Collecting cryptography<39,>=38.0.0 (from pyopenssl==22.1.0->-r test-requirements.txt (line 3))

Isso parece ser uma restrição do requirements do Odoo
odoo/src/requirements.txt:52:pyopenssl==20.0.1; python_version < '3.12'

Bom no caso de quem usa a LIB com o Odoo depois da v16 ou se o ambiente ainda na v16 vier a ser atualizado para o Python 3.12 ou a imagem usada está instalando a versão mais recente do PyOpenSSL esse PR pode acabar antecipando essa questão.