### PR TITLE
[FIX] Alteração para remover qualquer conteudo entre o final e o inicio das tags

### DIFF
--- a/src/erpbrasil/assinatura/assinatura.py
+++ b/src/erpbrasil/assinatura/assinatura.py
@@ -60,6 +60,8 @@ class Assinatura(object):
         for element in xml_element.iter("*"):
             if element.text is not None and not element.text.strip():
                 element.text = None
+            if element.tail is not None and not element.tail.strip():
+                element.tail = None
 
         signer = XMLSignerWithSHA1(
             method=signxml.methods.enveloped,


### PR DESCRIPTION
Esse PR tem o objetivo de eliminar qualquer conteúdo entre o final da tag e inicio da próxima tag, esse PR está relacionado com a correção https://github.com/erpbrasil/erpbrasil.edoc/pull/97